### PR TITLE
Member database API changes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -28,4 +28,3 @@ src/creds/*
 reports
 code-signing
 neo4j-*
-testrig

--- a/src/api/Database.js
+++ b/src/api/Database.js
@@ -59,8 +59,9 @@ export default class Database {
             name: 'neo4j',
             currentStatus: 'online',
             requestedStatus: 'online',
+            role: 'LEADER',
             default: true,
-            error: null,
+            error: '',
             address: '',
         }]);
     }

--- a/src/api/Database.js
+++ b/src/api/Database.js
@@ -89,7 +89,6 @@ export default class Database {
             resultingDBs.push(new Database(dbs[dbName]));
         });
 
-        console.log(resultingDBs);
         return resultingDBs;
     }
 
@@ -104,7 +103,7 @@ export default class Database {
     isReconciling() {
         let reconciling = false;
         this.backingStatuses.forEach(s => {
-            reconciling = reconciling || (this.currentStatus !== this.requestedStatus);
+            reconciling = reconciling || (s.currentStatus !== s.requestedStatus);
         });
 
         return reconciling;

--- a/src/api/Database.test.js
+++ b/src/api/Database.test.js
@@ -1,0 +1,112 @@
+import api from './index';
+import Database from './Database';
+
+const makeRecord = (database, host, status, role='FOLLOWER', def) => ({
+    name: database,
+    address: host,
+    role,
+    requestedStatus: status,
+    currentStatus: status,
+    error: '',
+    default: def,
+})
+
+const showDatabaseResults = [
+    makeRecord('system', 'core1:7687', 'online', 'LEADER', false),
+    makeRecord('system', 'core2:7687', 'online', 'FOLLOWER', false),
+    makeRecord('system', 'core3:7687', 'online', 'FOLLOWER', false),
+    makeRecord('mydb', 'core1:7687', 'online', 'FOLLOWER', true),
+    makeRecord('mydb', 'core2:7687', 'online', 'LEADER', true),
+    makeRecord('mydb', 'core3:7687', 'online', 'FOLLOWER', true),
+];
+
+describe('Database', function() {
+    let dbs;
+    let system;
+    let mydb;
+
+    beforeEach(() => {
+        dbs = Database.fromArrayOfResults(showDatabaseResults);
+        
+        system = dbs.filter(d => d.name === 'system')[0];
+        mydb = dbs.filter(d => d.name === 'mydb')[0];
+
+        // throw new Error(JSON.stringify(dbs.map(d => d.asJSON()), null, 2));
+    });
+
+    it('creates results correctly', () => {
+        expect(dbs.length).toEqual(2);
+
+        expect(system).toBeTruthy();
+        expect(mydb).toBeTruthy();
+    });
+
+    it('has a label that matches name', () => {
+        expect(system.getLabel()).toEqual('system');
+        expect(mydb.getLabel()).toEqual('mydb');
+    });
+
+    it('knows how to detect errors', () => {
+        mydb.backingStatuses[2].error = 'Something went wrong!';
+
+        expect(mydb.hasError()).toBeTruthy();
+        expect(system.hasError()).toBeFalsy();
+    });
+
+    it('can return member statuses', () => {
+        const s = system.getMemberStatuses();
+        expect(s instanceof Array).toBeTruthy();
+        expect(s.length).toEqual(3);
+    });
+
+    it('Knows about unique and differing statuses', () => {
+        system.backingStatuses[1].currentStatus = 'b0rked';
+
+        const statuses = system.getStatuses();
+
+        expect(statuses.indexOf('b0rked') > -1).toBeTruthy();
+        expect(statuses.indexOf('online') > -1).toBeTruthy();
+    });
+
+    it('can return singular status', () => {
+        expect(mydb.getStatus()).toEqual('online');
+    });
+
+    it('knows if it is online', () => {
+        expect(mydb.isOnline()).toBeTruthy();
+
+        mydb.backingStatuses[1].currentStatus = 'b0rked';
+        expect(mydb.isOnline()).toBeFalsy();
+    });
+
+    it('knows if it is reconciling', () => {
+        // Current status is online but requested to be stopped.
+        mydb.backingStatuses[1].requestedStatus = 'stopped';
+        expect(mydb.isReconciling()).toBeTruthy();
+    });
+
+    it('knows if it has an error', () => {
+        const err = 'something went wrong';
+        mydb.backingStatuses[2].error = err;
+        expect(mydb.hasError()).toBeTruthy();
+    });
+
+    it('can create a pre-Neo4j 4.0 dummy database', () => {
+        const d = Database.pre4DummyDatabase();
+        expect(d).toBeTruthy();
+        expect(d.name).toEqual(Database.SINGLEDB_NAME);
+        expect(d.isOnline()).toBeTruthy();
+        expect(d.isDefault()).toBeTruthy();
+    });
+
+    it('knows if it is default', () => {
+        expect(mydb.isDefault()).toBeTruthy();
+        expect(system.isDefault()).toBeFalsy();
+    });
+
+    it('can make JSON of itself', () => {
+        const obj = system.asJSON();
+        expect(obj).toBeTruthy();
+        expect(obj.name).toEqual('system');
+    });
+});

--- a/src/api/Database.test.js
+++ b/src/api/Database.test.js
@@ -1,4 +1,3 @@
-import api from './index';
 import Database from './Database';
 
 const makeRecord = (database, host, status, role='FOLLOWER', def) => ({

--- a/src/api/HalinContext.test.js
+++ b/src/api/HalinContext.test.js
@@ -33,7 +33,7 @@ describe('Halin Context', function () {
         expect(ctx.mgr).toBeTruthy();
     });
 
-    it('has a members accessor', () => expect(ctx.members()).toEqual(ctx.clusterMembers));
+    it('has a members accessor', () => expect(ctx.members()).toEqual(ctx.memberSet.clusterMembers));
     it('exposes a poll rate', () => expect(ctx.getPollRate()).toEqual(ctx.pollRate));
     it('exposes a cluster manager', () => expect(ctx.getClusterManager()).toBeInstanceOf(ClusterManager));
     it('can get a driver for an address', () => {

--- a/src/api/cluster/ClusterManager.js
+++ b/src/api/cluster/ClusterManager.js
@@ -354,7 +354,15 @@ export default class ClusterManager {
             .then(packageClusterOpResults);
     }
 
+    /**
+     * Returns the last cached set of databases, does *not* re-query for databases.
+     * @returns Array<Database>
+     */
     databases() { return this._dbs; }
+
+    getDatabaseByName(name) {
+        return this._dbs.filter(db => db.name === name)[0];
+    }
 
     getDefaultDatabase() {
         return this.databases().filter(db => db.isDefault())[0];

--- a/src/api/cluster/ClusterManager.test.js
+++ b/src/api/cluster/ClusterManager.test.js
@@ -14,6 +14,7 @@ const fakeAMember = (role='FOLLOWER') => {
         id: i,
         addresses: [httpAddress, boltAddress],
         role,
+        groups: [],
         database: 'ABC',
     };
     const fakeRecord = fakes.record(entry);

--- a/src/api/cluster/ClusterMember.js
+++ b/src/api/cluster/ClusterMember.js
@@ -27,7 +27,7 @@ export default class ClusterMember {
         if (record.has('databases')) {
             // >= Neo4j 4.0
             // TODO: Raft roles can't separate in 4.0. If you're the leader for one
-            // DB you're the leader for all of them and so forth.
+            // DB you're th e leader for all of them and so forth.
             // THIS IS A LIMITED ASSUMPTION FOR 4.0 AND WILL CHANGE.
             // But this assumption is specifically why any role is fine to take as
             // the cluster member's role.
@@ -36,10 +36,17 @@ export default class ClusterMember {
                 const role = dbs[dbName];
                 this.role = role;
             });
+
+            // Maps database name to member role
             this.database = dbs;
         } else {
             this.role = (record.get('role') || '').trim();
-            this.database = record.get('database');
+            const key = record.get('database');
+            const value = this.role;
+            const obj = { [key]: value };
+
+            // Maps database name to member role
+            this.database = obj;
         }
 
         this.id = record.get('id');
@@ -49,6 +56,26 @@ export default class ClusterMember {
         this.driver = null;
         this.observations = new Ring(MAX_OBSERVATIONS);
         this.errors = {};
+    }
+
+    /**
+     * When Neo4j is in standalone mode (non CC) Halin fakes this as a cluster of 1 member.
+     * This provides some basic details (id, addresses, role, database) and creates a member
+     * from that.
+     * @param {Object} details 
+     */
+    static makeStandalone(halin, details) {
+        // Psuedo object behaves like a cypher result record.
+        // Somewhere, a strong typing enthusiast is screaming. ;)
+        const get = key => details[key];
+        const has = key => !_.isNil(details[key]);
+        details.get = get;
+        details.has = has;
+
+        const member = new ClusterMember(details);
+        const driver = halin.driverFor(member.getBoltAddress());
+        member.setDriver(driver);
+        return member;
     }
 
     /**
@@ -141,11 +168,16 @@ export default class ClusterMember {
     isFollower() { return this.role === 'FOLLOWER'; }
     isSingle() { return this.role === 'SINGLE'; }
     isReadReplica() { return this.role === 'READ_REPLICA'; }
+
     isCore() {
         return this.isLeader() || this.isSingle();
     }
-    canWrite() {
-        return this.isLeader() || this.isSingle();
+
+    canWrite(db = null) {
+        if (this.isSingle()) { return true; }
+
+        if (db === null) { return this.isLeader(); }
+        return this.database[db] === 'LEADER';
     }
 
     /**
@@ -346,8 +378,7 @@ export default class ClusterMember {
                 const e = new Date().getTime() - s;
                 sentry.fine(this.getLabel(), 'initialization', e, 'ms elapsed');
                 return whatever;
-            })
-            .then(() => this.watchForClusterRoleChange());
+            });
     }
 
     _txSuccess(time) {
@@ -440,51 +471,5 @@ export default class ClusterMember {
                 return poolSession ? this.pool.release(s)
                     .catch(e => sentry.fine('Pool release error', e)) : p;
             });
-    }
-
-    /**
-     * Starts a slow data feed for the node's cluster role.  In this way, if the leader
-     * changes, we can detect it.
-     */
-    watchForClusterRoleChange(clusterMember) {
-
-        console.log('watchForClusterRoleChange TBD');
-
-        return Promise.resolve(true);
-
-        // const roleFeed = this.getDataFeed(_.merge({
-        //     node: clusterMember,
-        // }, queryLibrary.CLUSTER_ROLE));
-
-        // const addr = clusterMember.getBoltAddress();
-        // const onRoleData = (newData /* , dataFeed */) => {
-        //     const newRole = newData.data[0].role;
-
-        //     // Something in cluster topology just changed...
-        //     if (newRole !== clusterMember.role) {
-        //         const oldRole = clusterMember.role;
-        //         clusterMember.role = newRole;
-
-        //         const event = {
-        //             message: `Role change from ${oldRole} to ${newRole}`,
-        //             type: 'rolechange',
-        //             address: clusterMember.getBoltAddress(),
-        //             payload: {
-        //                 old: oldRole,
-        //                 new: newRole,
-        //             },
-        //         };
-
-        //         this.getClusterManager().addEvent(event);
-        //     }
-        // };
-
-        // const onError = (err /*, dataFeed */) =>
-        //     sentry.reportError(err, `HalinContext: failed to get cluster role for ${addr}`);
-
-        // roleFeed.addListener(onRoleData);
-        // roleFeed.onError = onError;
-        // return roleFeed;
-
     }
 }

--- a/src/api/cluster/ClusterMember.test.js
+++ b/src/api/cluster/ClusterMember.test.js
@@ -9,6 +9,7 @@ describe('ClusterMember', function () {
     const entry = {
         id: 'XYZ',
         addresses: [httpAddress, boltAddress],
+        groups: [],
         role: 'LEADER',
         database: 'ABC',        
     };
@@ -23,7 +24,7 @@ describe('ClusterMember', function () {
         expect(c.id).toEqual(entry.id);
         expect(c.addresses).toEqual(entry.addresses);
         expect(c.role).toEqual(entry.role);
-        expect(c.database).toEqual(entry.database);
+        expect(c.database.ABC).toEqual('LEADER');
     });
 
     it('exposes getObservations', () => {

--- a/src/api/cluster/ClusterMemberSet.js
+++ b/src/api/cluster/ClusterMemberSet.js
@@ -8,6 +8,8 @@ import uuid from 'uuid';
 /**
  * This class is a wrapper for a set of ClusterMember objects, and handles housekeeping
  * about keeping them up to date with the evolving cluster state.
+ * #operability Neo4j doesn't really expose a "Cluster" abstraction, so this is a part of
+ * the abstraction that Halin puts on top to make all of this possible.
  */
 export default class ClusterMemberSet {
     constructor() {

--- a/src/api/cluster/ClusterMemberSet.js
+++ b/src/api/cluster/ClusterMemberSet.js
@@ -163,6 +163,5 @@ export default class ClusterMemberSet {
         // roleFeed.addListener(onRoleData);
         // roleFeed.onError = onError;
         // return roleFeed;
-
     }
 }

--- a/src/api/cluster/ClusterMemberSet.js
+++ b/src/api/cluster/ClusterMemberSet.js
@@ -1,0 +1,166 @@
+import _ from 'lodash';
+import queryLibrary from '../data/queries/query-library';
+import ClusterMember from './ClusterMember';
+import errors from '../driver/errors';
+import sentry from '../sentry';
+import uuid from 'uuid';
+
+/**
+ * This class is a wrapper for a set of ClusterMember objects, and handles housekeeping
+ * about keeping them up to date with the evolving cluster state.
+ */
+export default class ClusterMemberSet {
+    constructor() {
+        this.clusterMembers = [];
+    }
+
+    members() { return this.clusterMembers; }
+
+    shutdown() {
+        return Promise.all(this.clusterMembers.map(member => member.shutdown()))
+            .catch(err => sentry.reportError(err, 'Failure to shut down cluster members', err));
+    }
+
+    initialize(halin, driver, progressCallback) {
+        const session = driver.session();
+
+        const report = str => progressCallback ? progressCallback(str) : null;
+
+        report('Checking cluster status');
+        return session.run(queryLibrary.CLUSTER_OVERVIEW.query)
+            .then(results => {
+                console.log('RESULTS',results);
+                this.clusterMembers = results.records.map(rec => new ClusterMember(rec));
+
+                // Note that in the case of community or mode=SINGLE, because the cluster overview fails,
+                // this will never take place.  Watching for cluster role changes doesn't apply in those cases.
+                return this.clusterMembers.map(clusterMember => {
+                    const driver = halin.driverFor(clusterMember.getBoltAddress());
+                    clusterMember.setDriver(driver);
+                    return report(`Member ${clusterMember.getLabel()} initialized`);
+                });
+            })
+            .catch(err => {
+                if (errors.noProcedure(err)) {
+                    // Halin will look at single node databases
+                    // running in desktop as clusters of size 1.
+                    // #operability I wish Neo4j treated mode=SINGLE as a cluster of 1 and exposed dbms.cluster.*
+                    const base = halin.getBaseDetails();
+
+                    const host = base.host;
+                    const port = base.port;
+                    const addresses = [`bolt://${host}:${port}`];
+
+                    const rec = {
+                        id: uuid.v4(),
+                        addresses,
+                        role: 'SINGLE',
+                        database: 'default',
+                    };
+
+                    this.clusterMembers = [ClusterMember.makeStandalone(halin, rec)];
+                } else {
+                    sentry.reportError(err);
+                    throw err;
+                }
+            })
+            .then(() => report('Verifying connectivity with members...'))
+            .then(() => {
+                console.log('At this point members are ', this.members());
+            })
+            .then(() => 
+                Promise.all(this.members().map(member => this.ping(halin, member))))
+            .then(() => report('Checking components/features for each cluster member...'))
+            .then(() => Promise.all(this.members().map(member => member.checkComponents())))
+            .then(() => Promise.all(this.members().map(member => this.watchForClusterRoleChange(member))))
+            .finally(() => session.close());
+    }
+
+    /**
+     * Ping a cluster node with a trivial query, just to keep connections
+     * alive and verify it's still listening.  This forces driver creation
+     * for a node if it hasn't already happened.
+     * @param {ClusterMember} the node to ping
+     * @returns {Promise} that resolves to an object with an elapsedMs field
+     * or an err field populated.
+     */
+    ping(halin, clusterMember) {
+        const addr = clusterMember.getBoltAddress();
+
+        // Gets or creates a ping data feed for this cluster node.
+        // Data feed keeps running so that we can deliver the data to the user,
+        // but also have a feed of data to know if the cord is getting unplugged
+        // as the app runs.
+        const pingFeed = halin.getDataFeed(_.merge({
+            node: clusterMember,
+        }, queryLibrary.PING));
+
+        // Caller needs a promise.  The feed is already running, so 
+        // We return a promise that resolves the next time the data feed
+        // comes back with a result.
+        return new Promise((resolve, reject) => {
+            const onPingData = (newData /* , dataFeed */) => {
+                return resolve({
+                    clusterMember: clusterMember,
+                    elapsedMs: _.get(newData, 'data[0]_sampleTime'),
+                    newData,
+                    err: null,
+                });
+            };
+
+            const onError = (err, dataFeed) => {
+                sentry.error('ClusterMemberSet: failed to ping', addr, err);
+                reject(err, dataFeed);
+            };
+
+            pingFeed.addListener(onPingData);
+            pingFeed.onError = onError;
+        });
+    }
+
+    /**
+     * Starts a slow data feed for the node's cluster role.  In this way, if the leader
+     * changes, we can detect it.
+     */
+    watchForClusterRoleChange(clusterMember) {
+        console.log('watchForClusterRoleChange TBD');
+
+        return Promise.resolve(true);
+        // TODO
+
+        // const roleFeed = this.getDataFeed(_.merge({
+        //     node: clusterMember,
+        // }, queryLibrary.CLUSTER_ROLE));
+
+        // const addr = clusterMember.getBoltAddress();
+        // const onRoleData = (newData /* , dataFeed */) => {
+        //     const newRole = newData.data[0].role;
+
+        //     // Something in cluster topology just changed...
+        //     if (newRole !== clusterMember.role) {
+        //         const oldRole = clusterMember.role;
+        //         clusterMember.role = newRole;
+
+        //         const event = {
+        //             message: `Role change from ${oldRole} to ${newRole}`,
+        //             type: 'rolechange',
+        //             address: clusterMember.getBoltAddress(),
+        //             payload: {
+        //                 old: oldRole,
+        //                 new: newRole,
+        //             },
+        //         };
+
+        //         this.getClusterManager().addEvent(event);
+        //     }
+        // };
+
+        // const onError = (err /*, dataFeed */) =>
+        //     sentry.reportError(err, `HalinContext: failed to get cluster role for ${addr}`);
+
+        // roleFeed.addListener(onRoleData);
+        // roleFeed.onError = onError;
+        // return roleFeed;
+
+    }
+}

--- a/src/api/cluster/ClusterMemberSet.test.js
+++ b/src/api/cluster/ClusterMemberSet.test.js
@@ -1,0 +1,59 @@
+import ClusterMember from './ClusterMember';
+import ClusterMemberSet from './ClusterMemberSet';
+import HalinContext from '../HalinContext';
+import fakes from '../../testutils/fakes';
+import neo4j from '../driver/index';
+import sinon from 'sinon';
+import queryfakes from '../../testutils/queryfakes';
+
+describe('ClusterMemberSet', function () {
+    let ctx;
+    let memberSet;
+
+    beforeEach(() => {
+        memberSet = new ClusterMemberSet();
+        HalinContext.connectionDetails = fakes.basics;
+        ctx = new HalinContext();
+        neo4j.driver = sinon.fake.returns(fakes.Driver());
+
+        return memberSet.initialize(ctx, fakes.Driver());
+    });
+
+    afterEach(() => sinon.restore());
+
+    it('can be constructed and initialized correctly', () => {
+        expect(memberSet).toBeTruthy();
+
+        // These are the IDs of cluster members that our fake construct made
+        const ids = queryfakes['CALL dbms.cluster.overview'].map(rec => rec.id);
+
+        expect(memberSet.members().length).toEqual(ids.length);
+
+        // We found all of our expected IDs.
+        memberSet.members().forEach(m => {
+            expect(ids.indexOf(m.id) > -1).toBeTruthy();
+        });
+    });
+
+    it('calls member shutdown functions when the set is shut down', () => {
+        memberSet.clusterMembers.forEach(m => {
+            m.shutdown = sinon.fake.returns(Promise.resolve(true));
+        });
+
+        return memberSet.shutdown()
+            .then(() => {
+                memberSet.clusterMembers.forEach(m => {
+                    expect(m.shutdown.callCount).toEqual(1);
+                });
+            });
+    });
+
+    it('has a members accessor that returns clusterMembers', () => {
+        const arr = memberSet.members();
+        expect(arr instanceof Array).toBeTruthy();
+
+        arr.forEach(member => {
+            expect(member instanceof ClusterMember).toBeTruthy();
+        });
+    });
+});

--- a/src/api/cluster/health/score.js
+++ b/src/api/cluster/health/score.js
@@ -27,6 +27,7 @@ const feedFreshness = (ctx, member) => {
         fresh,
         notFresh,
         performance: member.performance(),
+        created: new Date(),
     };
 };
 

--- a/src/components/database/CreateDatabase/CreateDatabase.js
+++ b/src/components/database/CreateDatabase/CreateDatabase.js
@@ -1,6 +1,6 @@
 import React, { Component } from 'react';
 import PropTypes from 'prop-types';
-import { Button, Modal, Form, Message } from 'semantic-ui-react';
+import { Button, Form, Message } from 'semantic-ui-react';
 import _ from 'lodash';
 import sentry from '../../../api/sentry';
 import status from '../../../api/status/index';

--- a/src/components/database/DatabaseOverview/DatabaseOverview.js
+++ b/src/components/database/DatabaseOverview/DatabaseOverview.js
@@ -1,10 +1,11 @@
 import React, { Component } from 'react';
 import PropTypes from 'prop-types';
+import moment from 'moment';
+import _ from 'lodash';
 
 import HalinCard from '../../ui/scaffold/HalinCard/HalinCard';
 import Explainer from '../../ui/scaffold/Explainer/Explainer';
 import { List } from 'semantic-ui-react';
-import moment from 'moment';
 
 class DatabaseOverview extends Component {
     status(s) {
@@ -22,13 +23,15 @@ class DatabaseOverview extends Component {
 
     render() {
         console.log(this.props);
+        const leader = this.props.database.getLeader(window.halinContext);
+
         return (
             <HalinCard id="DatabaseOverview">
                 <h3>Database Overview <Explainer knowledgebase='Database' /></h3>
                
                 <List>
                     {
-                        this.props.database.getMemberStatuses().map((s, i) => 
+                        _.sortBy(this.props.database.getMemberStatuses(), ['address']).map((s, i) => 
                             <List.Item key={i}>
                                 {s.address}&nbsp;
                                 <strong>{(''+s.role).toUpperCase()}</strong>&nbsp;
@@ -36,10 +39,10 @@ class DatabaseOverview extends Component {
                                 &nbsp;{ this.errorInformation(s) }
                             </List.Item>)
                     }
-
                 </List>
 
                 <p>Last updated: { moment(this.props.database.created).format() }</p>
+                <p>Leader ID: {leader.id}</p>
             </HalinCard>
         );
     };

--- a/src/components/database/DatabasePane/DatabasePane.js
+++ b/src/components/database/DatabasePane/DatabasePane.js
@@ -11,8 +11,8 @@ import DatabaseOverview from '../DatabaseOverview/DatabaseOverview';
 const DatabasePane = (props) => {
     return (
         <Card.Group itemsPerRow={2} className="DatabasePane">
-            <AdministerDatabase {...props} />
             <DatabaseOverview {...props} />
+            <AdministerDatabase {...props} />
             { window.halinContext.supportsAPOC() ? <ApocMetaStats {...props} /> : '' }
             { 
                 // Due to JMX changes in 4.0, this component isn't workable >= 4.0.

--- a/src/components/performance/ClusterMemberOverview/ClusterMemberOverview.js
+++ b/src/components/performance/ClusterMemberOverview/ClusterMemberOverview.js
@@ -2,7 +2,7 @@ import React from 'react';
 import PropTypes from 'prop-types';
 
 import { Card } from 'semantic-ui-react';
-
+import MemberOverviewCard from '../MemberOverviewCard/MemberOverviewCard';
 import MemoryMonitor from '../MemoryMonitor/MemoryMonitor';
 import SystemLoad from '../SystemLoad/SystemLoad';
 import TransactionMonitor from '../TransactionMonitor/TransactionMonitor';
@@ -11,9 +11,10 @@ import TransactionMonitor from '../TransactionMonitor/TransactionMonitor';
 const ClusterMemberOverview = (props) => {
     return (
         <Card.Group itemsPerRow={2} className="ClusterMemberOverview">
-            <SystemLoad node={props.node} />
-            <MemoryMonitor node={props.node} />
-            <TransactionMonitor node={props.node} />
+            <MemberOverviewCard member={props.member} />
+            <SystemLoad member={props.member} />
+            <MemoryMonitor member={props.member} />
+            <TransactionMonitor member={props.member} />
             {/* <DiskUtilizationPieChart node={props.node} /> */}
         </Card.Group>
     );

--- a/src/components/performance/ClusterMemberOverview/ClusterMemberOverview.js
+++ b/src/components/performance/ClusterMemberOverview/ClusterMemberOverview.js
@@ -8,9 +8,9 @@ import SystemLoad from '../SystemLoad/SystemLoad';
 import TransactionMonitor from '../TransactionMonitor/TransactionMonitor';
 // import DiskUtilizationPieChart from '../../database/DiskUtilizationPieChart/DiskUtilizationPieChart';
 
-const PerformancePane = (props) => {
+const ClusterMemberOverview = (props) => {
     return (
-        <Card.Group itemsPerRow={2} className="PerformancePane">
+        <Card.Group itemsPerRow={2} className="ClusterMemberOverview">
             <SystemLoad node={props.node} />
             <MemoryMonitor node={props.node} />
             <TransactionMonitor node={props.node} />
@@ -19,8 +19,8 @@ const PerformancePane = (props) => {
     );
 }
 
-PerformancePane.props = {
+ClusterMemberOverview.props = {
     node: PropTypes.object.isRequired, // TODO: shape?
 }
 
-export default PerformancePane;
+export default ClusterMemberOverview;

--- a/src/components/performance/MemberOverviewCard/MemberOverviewCard.js
+++ b/src/components/performance/MemberOverviewCard/MemberOverviewCard.js
@@ -1,41 +1,85 @@
-import React from 'react';
+import React, { Component } from 'react';
 import PropTypes from 'prop-types';
 import HalinCard from '../../ui/scaffold/HalinCard/HalinCard';
-import { List } from 'semantic-ui-react';
+import { List, Grid } from 'semantic-ui-react';
+import util from '../../../api/data/util.js';
 
-const MemberOverviewCard = (props) => {
-    const roles = props.member.getDatabaseRoles();
-    const databases = Object.keys(roles);
+import SignalMeter from '../../data/SignalMeter/SignalMeter';
 
-    return (
-        <HalinCard owner={this}>
-            <h3>Member Overview</h3>
+class MemberOverviewCard extends Component {
+    state = {
+        currentState: null,
+        score: 1,
+        total: 1,
+        fresh: 1,
+        notFresh: 0,
+        performance: { observations: [] },
+    };
 
-            <List style={{ textAlign: 'left' }}>
-                {databases.map((dbName, k) =>
-                    <List.Item key={k}>
-                        <strong>{dbName}</strong>: {roles[dbName]}
-                    </List.Item>)}
-            </List>
+    sampleFeeds() {
+        if (!this.mounted) { return null; }
+        const score = this.props.member.getHealthScore(window.halinContext);
+        this.setState(score);
+    }
 
-            <List style={{ textAlign: 'left' }}>
-                <List.Item>
-                    <List.Icon name='tags' />
-                    <List.Content>{props.member.id}</List.Content>
-                </List.Item>
+    componentDidMount() {
+        this.mounted = true;
+        this.interval = setInterval(() => this.sampleFeeds(), 500);
+    }
 
-                {props.member.groups && props.member.groups.length > 0 ? <List.Item>
-                    <List.Icon name='group' />
-                    <List.Content>{props.member.groups}</List.Content>
-                </List.Item> : ''}
+    componentWillUnmount() {
+        this.mounted = false;
+        clearInterval(this.interval);
+    }
 
-                <List.Item>
-                    <List.Icon name='address book' />
-                    <List.Content>{props.member.addresses.join(', ')}</List.Content>
-                </List.Item>
-            </List>
-        </HalinCard>
-    );
+    render() {
+        const roles = this.props.member.getDatabaseRoles();
+        const databases = Object.keys(roles);
+        databases.sort();
+
+        return (
+            <HalinCard owner={this}>
+                <h3>Member Overview</h3>
+
+                <List style={{ textAlign: 'left' }}>
+                    {databases.map((dbName, k) =>
+                        <List.Item key={k}>
+                            <strong>{dbName}</strong>: {roles[dbName]}
+                        </List.Item>)}
+                </List>
+
+                <List style={{ textAlign: 'left' }}>
+                    <List.Item>
+                        <List.Icon name='tags' />
+                        <List.Content>{this.props.member.id}</List.Content>
+                    </List.Item>
+
+                    {this.props.member.groups && this.props.member.groups.length > 0 ? <List.Item>
+                        <List.Icon name='group' />
+                        <List.Content>{this.props.member.groups}</List.Content>
+                    </List.Item> : ''}
+
+                    <List.Item>
+                        <List.Icon name='address book' />
+                        <List.Content>{this.props.member.addresses.join(', ')}</List.Content>
+                    </List.Item>
+                </List>
+
+                <Grid>
+                    <Grid.Row>
+                        <Grid.Column width={2}>
+                            <SignalMeter strength={util.signalStrengthFromFreshRatio(this.state.fresh, this.state.total)} />
+                        </Grid.Column>
+                        <Grid.Column width={14}>
+                            <p>{`${this.state.fresh} of ${this.state.total} fresh`};&nbsp;
+                                {this.state.performance.observations.length} observations; mean response
+                                &nbsp;{util.roundToPlaces(this.state.performance.mean, 0)}ms with stdev {util.roundToPlaces(this.state.performance.stdev, 0)}ms</p>
+                        </Grid.Column>
+                    </Grid.Row>
+                </Grid>
+            </HalinCard>
+        );
+    }
 }
 
 MemberOverviewCard.props = {

--- a/src/components/performance/MemberOverviewCard/MemberOverviewCard.js
+++ b/src/components/performance/MemberOverviewCard/MemberOverviewCard.js
@@ -1,0 +1,17 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import HalinCard from '../../ui/scaffold/HalinCard/HalinCard';
+
+const MemberOverviewCard = (props) => {
+    return (
+        <HalinCard owner={this}>
+            Member Overview
+        </HalinCard>        
+    );
+}
+
+MemberOverviewCard.props = {
+    member: PropTypes.object.isRequired,
+}
+
+export default MemberOverviewCard;

--- a/src/components/performance/MemberOverviewCard/MemberOverviewCard.js
+++ b/src/components/performance/MemberOverviewCard/MemberOverviewCard.js
@@ -1,12 +1,40 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import HalinCard from '../../ui/scaffold/HalinCard/HalinCard';
+import { List } from 'semantic-ui-react';
 
 const MemberOverviewCard = (props) => {
+    const roles = props.member.getDatabaseRoles();
+    const databases = Object.keys(roles);
+
     return (
         <HalinCard owner={this}>
-            Member Overview
-        </HalinCard>        
+            <h3>Member Overview</h3>
+
+            <List style={{ textAlign: 'left' }}>
+                {databases.map((dbName, k) =>
+                    <List.Item key={k}>
+                        <strong>{dbName}</strong>: {roles[dbName]}
+                    </List.Item>)}
+            </List>
+
+            <List style={{ textAlign: 'left' }}>
+                <List.Item>
+                    <List.Icon name='tags' />
+                    <List.Content>{props.member.id}</List.Content>
+                </List.Item>
+
+                {props.member.groups && props.member.groups.length > 0 ? <List.Item>
+                    <List.Icon name='group' />
+                    <List.Content>{props.member.groups}</List.Content>
+                </List.Item> : ''}
+
+                <List.Item>
+                    <List.Icon name='address book' />
+                    <List.Content>{props.member.addresses.join(', ')}</List.Content>
+                </List.Item>
+            </List>
+        </HalinCard>
     );
 }
 

--- a/src/components/performance/MemoryMonitor/MemoryMonitor.js
+++ b/src/components/performance/MemoryMonitor/MemoryMonitor.js
@@ -20,7 +20,7 @@ class MemoryMonitor extends Component {
             <HalinCard owner={this}>
                 <CypherTimeseries key={this.state.key}
                     heading="Memory Monitor"
-                    node={this.props.node}
+                    node={this.props.member}
                     explainer={explainer}
                     query={this.state.query} 
                     rate={this.state.rate}

--- a/src/components/performance/SystemLoad/SystemLoad.js
+++ b/src/components/performance/SystemLoad/SystemLoad.js
@@ -21,7 +21,7 @@ class SystemLoad extends Component {
                 <CypherTimeseries key={this.state.key}
                     heading="Load"
                     explainer={explainer}
-                    node={this.props.node}
+                    node={this.props.member}
                     query={this.state.query}
                     rate={this.state.rate}
                     displayColumns={this.state.displayColumns}

--- a/src/components/performance/TransactionMonitor/TransactionMonitor.js
+++ b/src/components/performance/TransactionMonitor/TransactionMonitor.js
@@ -27,7 +27,7 @@ class TransactionMonitor extends Component {
             <HalinCard owner={this}>
                 <CypherTimeseries key={this.state.key}
                     heading="Transaction Monitor"
-                    node={this.props.node}
+                    node={this.props.member}
                     query={this.state.query} 
                     explainer={explainer}
                     rate={this.state.rate}

--- a/src/components/ui/scaffold/ClusterMemberMenuItem/ClusterMemberMenuItem.js
+++ b/src/components/ui/scaffold/ClusterMemberMenuItem/ClusterMemberMenuItem.js
@@ -1,20 +1,27 @@
 import React, { Component } from 'react';
-import { Menu, Icon, Popup, Grid } from 'semantic-ui-react';
-
-import score from '../../../../api/cluster/health/score';
-import util from '../../../../api/data/util.js';
-
-import SignalMeter from '../../../data/SignalMeter/SignalMeter';
+import { Menu, Icon } from 'semantic-ui-react';
 
 export default class ClusterMemberMenuItem extends Component {
     state = {
-        currentState: null,
         score: 1,
-        total: 1,
-        fresh: 1,
-        notFresh: 0,
-        performance: { observations: [] },
     };
+
+    // Sampling feeds is needed to keep score updated in an ongoing way.
+    sampleFeeds() {
+        if (!this.mounted) { return null; }
+        const score = this.props.member.getHealthScore(window.halinContext);
+        this.setState(score);
+    }
+
+    componentDidMount() {
+        this.mounted = true;
+        this.interval = setInterval(() => this.sampleFeeds(), 500);
+    }
+
+    componentWillUnmount() {
+        this.mounted = false;
+        clearInterval(this.interval);
+    }
 
     statusIcon = (member) => {
         const role = member.role.toLowerCase();
@@ -37,58 +44,14 @@ export default class ClusterMemberMenuItem extends Component {
         return 'red';
     };
 
-    sampleFeeds() {
-        if (!this.mounted) { return null; }
-        const currentState = score.feedFreshness(window.halinContext, this.props.member);
-        this.setState(currentState);
-    }
-
-    componentDidMount() {
-        this.mounted = true;
-        this.interval = setInterval(() => this.sampleFeeds(), 500);
-    }
-
-    componentWillUnmount() {
-        this.mounted = false;
-        clearInterval(this.interval);
-    }
-
-    popupContent = () => {
-        return (
-            <div className='PopupContent'>
-                <Grid>
-                    <Grid.Column width={2}>
-                        <SignalMeter strength={util.signalStrengthFromFreshRatio(this.state.fresh, this.state.total)} />
-                    </Grid.Column>
-                    <Grid.Column width={14}>
-                        <p>{`${this.state.fresh} of ${this.state.total} fresh`};&nbsp;
-                            {this.state.performance.observations.length} observations; mean response 
-                            &nbsp;{util.roundToPlaces(this.state.performance.mean, 0)}ms with stdev {util.roundToPlaces(this.state.performance.stdev, 0)}ms</p>
-                    </Grid.Column>
-                </Grid>
-            </div>
-        );
-    };
-
     render() {
         return (
-            <Popup
-                inverted
-                position='right center'
-                wide='very'
-                key={this.props.member.getBoltAddress()}
-                trigger={
-                    <Menu.Item as='a'
-                        active={this.props.active}
-                        onClick={() => this.props.onSelect(this.props.member, this)}>
-                        {this.statusIcon(this.props.member)}
-                        {this.props.member.getLabel()}
-                    </Menu.Item>
-                }
-                header={`Role: ${this.props.member.role}`}
-                content={this.popupContent()}
-            />
-
+            <Menu.Item as='a'
+                active={this.props.active}
+                onClick={() => this.props.onSelect(this.props.member, this)}>
+                {this.statusIcon(this.props.member)}
+                {this.props.member.getLabel()}
+            </Menu.Item>
         );
     }
 }

--- a/src/components/ui/scaffold/MemberSelector/MemberSelector.js
+++ b/src/components/ui/scaffold/MemberSelector/MemberSelector.js
@@ -2,7 +2,7 @@ import React, { Component } from 'react';
 import { Sidebar, Segment, Menu, Tab, Divider } from 'semantic-ui-react';
 import uuid from 'uuid';
 
-import PerformancePane from '../../../performance/PerformancePane/PerformancePane';
+import ClusterMemberOverview from '../../../performance/ClusterMemberOverview/ClusterMemberOverview';
 import Neo4jConfiguration from '../../../configuration/Neo4jConfiguration/Neo4jConfiguration';
 import OSPane from '../../../performance/OSPane/OSPane';
 import PluginPane from '../../../db/PluginPane/PluginPane';
@@ -57,10 +57,10 @@ export default class MemberSelector extends Component {
             // objects.  
             // https://stackoverflow.com/questions/29074690/react-why-components-constructor-is-called-only-once
             {
-                menuItem: 'Performance',
+                menuItem: 'Overview',
                 visible: () => true,
                 render: () => this.paneWrapper(
-                    <PerformancePane key={key} node={member} />),
+                    <ClusterMemberOverview key={key} node={member} />),
             },
             {
                 menuItem: 'Queries',

--- a/src/components/ui/scaffold/MemberSelector/MemberSelector.js
+++ b/src/components/ui/scaffold/MemberSelector/MemberSelector.js
@@ -60,7 +60,7 @@ export default class MemberSelector extends Component {
                 menuItem: 'Overview',
                 visible: () => true,
                 render: () => this.paneWrapper(
-                    <ClusterMemberOverview key={key} node={member} />),
+                    <ClusterMemberOverview key={key} member={member} />),
             },
             {
                 menuItem: 'Queries',

--- a/testrig/TESTRIG-README.md
+++ b/testrig/TESTRIG-README.md
@@ -1,0 +1,5 @@
+# Test Rig
+
+This directory just contains utility scripts & docker compose setups for creating
+instances of Neo4j clusters or stand-alone instances, for the purpose of local testing.
+

--- a/testrig/create-empty-db.sh
+++ b/testrig/create-empty-db.sh
@@ -6,7 +6,8 @@ PASSWORD=admin
 CWD=`pwd`
 #NEO4J=neo4j:3.5.5
 #NEO4J=neo4j:4.0.0-alpha09
-NEO4J=neo4j:4.0.0-alpha09mr02-enterprise
+#NEO4J=neo4j:4.0.0-alpha09mr02-enterprise
+NEO4J=neo4j/neo4j-experimental:4.0.0-rc01-enterprise
 
 docker run -d --name neo4j-empty --rm \
 	-p 127.0.0.1:7474:7474 \

--- a/testrig/docker-compose.yml
+++ b/testrig/docker-compose.yml
@@ -1,0 +1,115 @@
+# Working docker-compose setup for causal cluster
+# See the image tag for which version we're using.
+version: '3'
+
+networks:
+  lan:
+
+services:
+
+  core1:
+    image: neo4j/neo4j-experimental:4.0.0-rc01-enterprise
+    networks:
+      - lan
+    ports:
+      - 7474:7474
+      - 6477:6477
+      - 7687:7687
+    volumes:
+      - $HOME/neo4j/neo4j-core401/conf:/conf
+      - $HOME/neo4j/neo4j-core401/data:/data
+      - $HOME/neo4j/neo4j-core401/logs:/logs
+      - $HOME/neo4j/neo4j-core401/plugins:/plugins
+    environment:
+#      - NEO4J_AUTH=none
+      - NEO4J_AUTH=neo4j/admin
+      - NEO4J_dbms_mode=CORE
+      - NEO4J_ACCEPT_LICENSE_AGREEMENT=yes      
+      - NEO4J_causal__clustering_initial__discovery__members=core1:5000,core2:5000,core3:5000
+      - NEO4J_causal__clustering_minimum__core__cluster__size__at__formation=3
+      - NEO4J_dbms_connector_http_listen__address=:7474
+      - NEO4J_dbms_connector_https_listen__address=:6477
+      - NEO4J_dbms_connector_bolt_listen__address=:7687
+      - NEO4J_dbms_connector_bolt_advertised__address=0.0.0.0:7687
+      - NEO4J_causal__clustering_discovery__advertised__address=core1:5000
+      - NEO4J_causal__clustering_transaction__advertised__address=core1:6000
+      - NEO4J_causal__clustering_raft__advertised__address=core1:7000
+      - NEO4J_config_strict__validation=true   
+      - NEO4J_dbms_memory_heap_initial__size=1024m
+      - NEO4J_dbms_memory_heap_max__size=1024m
+      - NEO4J_dbms_memory_pagecache_size=1g
+      - NEO4J_dbms_directories_import=import
+      - NEO4J_dbms_logs_query_enabled=INFO
+      - NEO4J_dbms_logs_query_threshold=0s
+      - NEO4J_dbms_default__database=demoDB
+
+  core2:
+    image: neo4j/neo4j-experimental:4.0.0-rc01-enterprise
+    networks:
+      - lan
+    ports:
+      - 7475:7475
+      - 6478:6478      
+      - 7688:7688      
+    volumes:
+      - $HOME/neo4j/neo4j-core402/conf:/conf
+      - $HOME/neo4j/neo4j-core402/data:/data
+      - $HOME/neo4j/neo4j-core402/logs:/logs
+      - $HOME/neo4j/neo4j-core402/plugins:/plugins      
+    environment:
+      - NEO4J_AUTH=neo4j/admin
+      - NEO4J_dbms_mode=CORE
+      - NEO4J_ACCEPT_LICENSE_AGREEMENT=yes      
+      - NEO4J_causal__clustering_minimum__core__cluster__size__at__formation=3
+      - NEO4J_causal__clustering_initial__discovery__members=core1:5000,core2:5000,core3:5000
+      - NEO4J_causal__clustering_discovery__advertised__address=core2:5000
+      - NEO4J_causal__clustering_transaction__advertised__address=core2:6000
+      - NEO4J_causal__clustering_raft__advertised__address=core2:7000
+      - NEO4J_dbms_connector_http_listen__address=:7475
+      - NEO4J_dbms_connector_https_listen__address=:6478
+      - NEO4J_dbms_connector_bolt_listen__address=:7688
+      - NEO4J_dbms_connector_bolt_advertised__address=0.0.0.0:7688
+      - NEO4J_config_strict__validation=true   
+      - NEO4J_dbms_memory_heap_initial__size=1024m
+      - NEO4J_dbms_memory_heap_max__size=1024m
+      - NEO4J_dbms_memory_pagecache_size=1g
+      - NEO4J_dbms_directories_import=import
+      - NEO4J_dbms_logs_query_enabled=INFO
+      - NEO4J_dbms_logs_query_threshold=0s
+      - NEO4J_dbms_default__database=demoDB
+      
+  core3:
+    image: neo4j/neo4j-experimental:4.0.0-rc01-enterprise
+    networks:
+      - lan
+    ports:
+      - 7476:7476
+      - 6479:6479      
+      - 7689:7689
+    volumes:
+      - $HOME/neo4j/neo4j-core403/conf:/conf
+      - $HOME/neo4j/neo4j-core403/data:/data
+      - $HOME/neo4j/neo4j-core403/logs:/logs
+      - $HOME/neo4j/neo4j-core403/plugins:/plugins
+    environment:
+      - NEO4J_AUTH=neo4j/admin
+      - NEO4J_dbms_mode=CORE
+      - NEO4J_ACCEPT_LICENSE_AGREEMENT=yes
+      - NEO4J_causal__clustering_minimum__core__cluster__size__at__formation=3
+      - NEO4J_causal__clustering_initial__discovery__members=core1:5000,core2:5000,core3:5000
+      - NEO4J_causal__clustering_discovery__advertised__address=core3:5000
+      - NEO4J_causal__clustering_transaction__advertised__address=core3:6000
+      - NEO4J_causal__clustering_raft__advertised__address=core3:7000
+      - NEO4J_dbms_connector_http_listen__address=:7476
+      - NEO4J_dbms_connector_https_listen__address=:6479      
+      - NEO4J_dbms_connector_bolt_listen__address=:7689
+      - NEO4J_dbms_connector_bolt_advertised__address=0.0.0.0:7689
+      - NEO4J_config_strict__validation=true   
+      - NEO4J_dbms_memory_heap_initial__size=1024m
+      - NEO4J_dbms_memory_heap_max__size=1024m
+      - NEO4J_dbms_memory_pagecache_size=1g
+      - NEO4J_dbms_directories_import=import
+      - NEO4J_dbms_logs_query_enabled=INFO
+      - NEO4J_dbms_logs_query_threshold=0s
+      - NEO4J_dbms_default__database=demoDB
+     


### PR DESCRIPTION
This branch refactors a lot of code and moves things around to create a cleaner API mapping for Neo4j 4.0.

In particular - the core concept here is that cluster members and databases are mapped together by leader/follower relationships.  For a given database, we need to know who is the leader.  For a given member, we need to be able to know what it is the leader of.

There are other UI changes in this branch as well that reflect and overview level of information about a given cluster member or database.

There's also better unit testing in this branch, and changing some responsibilities -- a HalinContext object now primarily consists of a ClusterManager, a ClusterMemberSet, and driver utilities.